### PR TITLE
Removes WebUtility.UrlEncode from paths

### DIFF
--- a/src/Narochno.Jenkins/JenkinsClient.cs
+++ b/src/Narochno.Jenkins/JenkinsClient.cs
@@ -45,7 +45,7 @@ namespace Narochno.Jenkins
 
         public async Task<UserInfo> GetUser(string user, CancellationToken ctx)
         {
-            var response = await GetRetryPolicy().ExecuteAsync(() => httpClient.GetAsync(jenkinsConfig.JenkinsUrl + "/user/" + WebUtility.UrlEncode(user) + "/api/json", ctx));
+            var response = await GetRetryPolicy().ExecuteAsync(() => httpClient.GetAsync(jenkinsConfig.JenkinsUrl + "/user/" + user + "/api/json", ctx));
 
             response.EnsureSuccessStatusCode();
 
@@ -54,7 +54,7 @@ namespace Narochno.Jenkins
 
         public async Task<ViewInfo> GetView(string view, CancellationToken ctx)
         {
-            var response = await GetRetryPolicy().ExecuteAsync(() => httpClient.GetAsync(jenkinsConfig.JenkinsUrl + "/view/" + WebUtility.UrlEncode(view) + "/api/json", ctx));
+            var response = await GetRetryPolicy().ExecuteAsync(() => httpClient.GetAsync(jenkinsConfig.JenkinsUrl + "/view/" + view + "/api/json", ctx));
 
             response.EnsureSuccessStatusCode();
 
@@ -63,7 +63,7 @@ namespace Narochno.Jenkins
 
         public async Task<BuildInfo> GetBuild(string job, string build, CancellationToken ctx)
         {
-            var response = await GetRetryPolicy().ExecuteAsync(() => httpClient.GetAsync(jenkinsConfig.JenkinsUrl + "/job/" + WebUtility.UrlEncode(job) + "/" + WebUtility.UrlEncode(build) + "/api/json", ctx));
+            var response = await GetRetryPolicy().ExecuteAsync(() => httpClient.GetAsync(jenkinsConfig.JenkinsUrl + "/job/" + job + "/" + build + "/api/json", ctx));
 
             response.EnsureSuccessStatusCode();
 
@@ -72,7 +72,7 @@ namespace Narochno.Jenkins
 
         public async Task<JobInfo> GetJob(string job, CancellationToken ctx)
         {
-            var response = await GetRetryPolicy().ExecuteAsync(() => httpClient.GetAsync(jenkinsConfig.JenkinsUrl + "/job/" + WebUtility.UrlEncode(job) + "/api/json", ctx));
+            var response = await GetRetryPolicy().ExecuteAsync(() => httpClient.GetAsync(jenkinsConfig.JenkinsUrl + "/job/" + job + "/api/json", ctx));
 
             response.EnsureSuccessStatusCode();
 
@@ -90,7 +90,7 @@ namespace Narochno.Jenkins
 
         public async Task BuildProject(string job, CancellationToken ctx = default(CancellationToken))
         {
-            var response = await GetRetryPolicy().ExecuteAsync(() => httpClient.PostAsync(jenkinsConfig.JenkinsUrl + "/job/" + WebUtility.UrlEncode(job) + "/build", null));
+            var response = await GetRetryPolicy().ExecuteAsync(() => httpClient.PostAsync(jenkinsConfig.JenkinsUrl + "/job/" + job + "/build", null));
 
             response.EnsureSuccessStatusCode();
         }

--- a/src/Narochno.Jenkins/Narochno.Jenkins.csproj
+++ b/src/Narochno.Jenkins/Narochno.Jenkins.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A simple Jenkins client, providing a C# wrapper around the default Jenkins API.</Description>
-    <VersionPrefix>1.1.2</VersionPrefix>
+    <Version>2.0.0</Version>
     <Authors>alanedwardes</Authors>
     <TargetFramework>netstandard1.3</TargetFramework>
     <AssemblyName>Narochno.Jenkins</AssemblyName>


### PR DESCRIPTION
Addresses https://github.com/Narochno/Narochno.Jenkins/issues/4

Forces the caller to URL encode things passed to the client, as components of views may contain slashes. Also removes encoding from all other calls to be consistent.