### PR TITLE
Add revisions

### DIFF
--- a/src/Narochno.Jenkins/Entities/Builds/ChangeSet.cs
+++ b/src/Narochno.Jenkins/Entities/Builds/ChangeSet.cs
@@ -6,5 +6,6 @@ namespace Narochno.Jenkins.Entities.Builds
     {
         public string Kind { get; set; }
         public IList<ChangeSetItem> Items { get; set; } = new List<ChangeSetItem>();
+        public IList<ChangeSetRevision> Revisions = new List<ChangeSetRevision>();
     }
 }

--- a/src/Narochno.Jenkins/Entities/Builds/ChangeSetRevision.cs
+++ b/src/Narochno.Jenkins/Entities/Builds/ChangeSetRevision.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Narochno.Jenkins.Entities.Builds
+{
+    public class ChangeSetRevision
+    {
+        public string Module { get; set; }
+        public string Revision { get; set; }
+    }
+}

--- a/src/Narochno.Jenkins/Narochno.Jenkins.csproj
+++ b/src/Narochno.Jenkins/Narochno.Jenkins.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A simple Jenkins client, providing a C# wrapper around the default Jenkins API.</Description>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <Authors>alanedwardes</Authors>
     <TargetFramework>netstandard1.3</TargetFramework>
     <AssemblyName>Narochno.Jenkins</AssemblyName>

--- a/test/Narochno.Jenkins.Tester/Program.cs
+++ b/test/Narochno.Jenkins.Tester/Program.cs
@@ -40,9 +40,9 @@ namespace Narochno.Jenkins.Tester
                 {
                     var buildInfo = await jenkinsClient.GetBuild(job.Name, build.Number.ToString());
 
-                    if (buildInfo.ChangeSet.Items.Count > 0)
+                    if (buildInfo.ChangeSet.Revisions.Count > 0)
                     {
-                        Console.WriteLine($"Got build {buildInfo} from {buildInfo.ChangeSet.Kind} revision {buildInfo.ChangeSet.Items.FirstOrDefault()}");
+                        Console.WriteLine($"Got build {buildInfo} from {buildInfo.ChangeSet.Kind} revision {buildInfo.ChangeSet.Revisions.FirstOrDefault().Revision}");
                     }
                 }
             }

--- a/test/Narochno.Jenkins.Tester/Program.cs
+++ b/test/Narochno.Jenkins.Tester/Program.cs
@@ -40,9 +40,9 @@ namespace Narochno.Jenkins.Tester
                 {
                     var buildInfo = await jenkinsClient.GetBuild(job.Name, build.Number.ToString());
 
-                    if (buildInfo.ChangeSet.Revisions.Count > 0)
+                    if (buildInfo.ChangeSet.Items.Count > 0)
                     {
-                        Console.WriteLine($"Got build {buildInfo} from {buildInfo.ChangeSet.Kind} revision {buildInfo.ChangeSet.Revisions.FirstOrDefault().Revision}");
+                        Console.WriteLine($"Got build {buildInfo} from {buildInfo.ChangeSet.Kind} revision {buildInfo.ChangeSet.Items.FirstOrDefault()}");
                     }
                 }
             }


### PR DESCRIPTION
The SVN version control provider returns a "revisions" object with the GetJob API, though providers like Git don't. Tested with SVN and Git.