### PR TITLE
Added basic support for BuildGraph

### DIFF
--- a/src/Narochno.Jenkins/Entities/Builds/BuildGraphInfo.cs
+++ b/src/Narochno.Jenkins/Entities/Builds/BuildGraphInfo.cs
@@ -1,0 +1,96 @@
+﻿using Narochno.Jenkins.Entities.Users;
+using Narochno.Primitives.Json;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Narochno.Jenkins.Entities.Builds
+{
+    public class BuildGraphInfo 
+    {
+        public BuildGraphNode[] Nodes { get; set; }
+
+        public static BuildGraphInfo Deserialize(string serializedBuildGraph, JsonSerializerSettings serializerSettings = null)
+        {
+            if (serializerSettings == null)
+                serializerSettings = new JsonSerializerSettings
+                {
+                    Converters = new JsonConverter[] { new OptionalJsonConverter(), new StringEnumConverter() }
+                };
+
+            var deserialized = JsonConvert.DeserializeObject<DeserializedBuildGraph>(serializedBuildGraph, serializerSettings);
+            var deserializedBuildGraphNodes = JsonConvert.DeserializeObject<DeserializedBuildGraphNodes>(deserialized.BuildGraph, serializerSettings);
+
+            var result = new BuildGraphInfo();
+            result.Nodes = deserializedBuildGraphNodes.Nodes.SelectMany(n => n.Nodes).ToArray();
+            
+
+            return result;
+        }
+    }
+
+    class DeserializedBuildGraph
+    {
+        public string Class { get; set; }
+
+        public string BuildGraph { get; set; }
+    }
+
+    class DeserializedBuildGraphNodes
+    {
+        public DeserializedBuildGraphNodesNodes[] Nodes { get; set; }
+    }
+
+    class DeserializedBuildGraphNodesNodes
+    {
+        public BuildGraphNode[] Nodes { get; set; }
+
+    }
+
+    public class BuildGraphNode
+    {
+        private string buildTitle = string.Empty;
+        private string jobName = string.Empty;
+        private string buildNumber = string.Empty;
+
+        public string NodeId { get; set; }
+        public int Row { get; set; }
+        public int Column { get; set; }
+        public string Title {
+            get { return buildTitle; }
+            set {
+                buildTitle = value;
+                var split = buildTitle.Split(' ');
+                jobName = split[0];
+                buildNumber = split[1].Substring(1);
+            }
+        }
+        public string JobName
+        {
+            get { return jobName; }
+        }
+        public string BuildNumber
+        {
+            get { return buildNumber; }
+        }
+
+        public string Color { get; set; }
+        public string BuildUrl { get; set; }
+        public string Description { get; set; }
+        public string Started { get; set; }
+        public string Running { get; set; }
+        public string Status { get; set; }
+        public string Progress { get; set; }
+        public DateTime StartTime { get; set; }
+        public string Duration { get; set; }
+        public string RrootUrl { get; set; }
+        public string Clockpng { get; set; }
+        public string Hourglasspng { get; set; }
+        public string Terminalpng { get; set; }
+        public string TimeStampString { get; set; }
+
+    }
+}

--- a/src/Narochno.Jenkins/IJenkinsClient.cs
+++ b/src/Narochno.Jenkins/IJenkinsClient.cs
@@ -12,6 +12,7 @@ namespace Narochno.Jenkins
     public interface IJenkinsClient : IDisposable
     {
         Task<BuildInfo> GetBuild(string job, string build, CancellationToken ctx = default(CancellationToken));
+        Task<BuildGraphInfo> GetBuildGraph(string job, string build, CancellationToken ctx = default(CancellationToken));
         Task<JobInfo> GetJob(string job, CancellationToken ctx = default(CancellationToken));
         Task<UserInfo> GetUser(string user, CancellationToken ctx = default(CancellationToken));
         Task<ViewInfo> GetView(string view, CancellationToken ctx = default(CancellationToken));

--- a/src/Narochno.Jenkins/JenkinsClient.cs
+++ b/src/Narochno.Jenkins/JenkinsClient.cs
@@ -15,6 +15,7 @@ using Narochno.Jenkins.Entities.Builds;
 using Narochno.Jenkins.Entities.Jobs;
 using Narochno.Jenkins.Entities.Views;
 using Narochno.Jenkins.Entities.Users;
+using System.Text.RegularExpressions;
 
 namespace Narochno.Jenkins
 {
@@ -70,6 +71,18 @@ namespace Narochno.Jenkins
             return JsonConvert.DeserializeObject<BuildInfo>(await response.Content.ReadAsStringAsync(), serializerSettings);
         }
 
+        public async Task<BuildGraphInfo> GetBuildGraph(string job, string build, CancellationToken ctx = default(CancellationToken))
+        {
+            var response = await GetRetryPolicy().ExecuteAsync(() => httpClient.GetAsync(jenkinsConfig.JenkinsUrl + "/job/" + job + "/" + build + "/BuildGraph/api/json", ctx));
+
+            response.EnsureSuccessStatusCode();
+
+            var content = await response.Content.ReadAsStringAsync();
+
+            return BuildGraphInfo.Deserialize(content, serializerSettings);
+            
+        }
+
         public async Task<JobInfo> GetJob(string job, CancellationToken ctx)
         {
             var response = await GetRetryPolicy().ExecuteAsync(() => httpClient.GetAsync(jenkinsConfig.JenkinsUrl + "/job/" + job + "/api/json", ctx));
@@ -103,5 +116,7 @@ namespace Narochno.Jenkins
         }
 
         public void Dispose() => httpClient.Dispose();
+
+        
     }
 }

--- a/test/Narochno.Jenkins.Tester/Program.cs
+++ b/test/Narochno.Jenkins.Tester/Program.cs
@@ -32,7 +32,7 @@ namespace Narochno.Jenkins.Tester
 
             var master = await jenkinsClient.GetMaster();
 
-            foreach (var job in master.Jobs.Where(j => j.Name.Contains("Quick") && j.Name.Contains("Dev")))
+            foreach (var job in master.Jobs.Where(j => j.Name.Contains("BuildTriggeringOtherBuilds")))
             {
                 var jobInfo = await jenkinsClient.GetJob(job.Name);
 

--- a/test/Narochno.Jenkins.Tester/Program.cs
+++ b/test/Narochno.Jenkins.Tester/Program.cs
@@ -32,6 +32,26 @@ namespace Narochno.Jenkins.Tester
 
             var master = await jenkinsClient.GetMaster();
 
+            foreach (var job in master.Jobs.Where(j => j.Name.Contains("Quick") && j.Name.Contains("Dev")))
+            {
+                var jobInfo = await jenkinsClient.GetJob(job.Name);
+
+                var build = jobInfo.Builds.Single(b => b.Number == jobInfo.Builds.Max(x => x.Number));
+                var buildInfo = await jenkinsClient.GetBuild(job.Name, build.Number.ToString());
+                var buildGraphInfo = await jenkinsClient.GetBuildGraph(job.Name, build.Number.ToString());
+
+                foreach (var node in buildGraphInfo.Nodes)
+                {
+                    var subBuildInfo = await jenkinsClient.GetBuild(node.JobName, node.BuildNumber.ToString());
+                    Console.WriteLine($"Got build {subBuildInfo}. Result {subBuildInfo.Result}");
+
+                    if (subBuildInfo.ChangeSet.Items.Count > 0)
+                    {
+                        Console.WriteLine($"Got build {subBuildInfo} from {subBuildInfo.ChangeSet.Kind} revision {subBuildInfo.ChangeSet.Items.FirstOrDefault()}");
+                    }
+                }
+            }
+
             foreach (var job in master.Jobs)
             {
                 var jobInfo = await jenkinsClient.GetJob(job.Name);


### PR DESCRIPTION
Hi,
I needed basic support for BuildGraph (from where I can get info what builds were triggered by the main build)
I didn't include all the proprs of the BuildGraph, only the nodes (sub builds).
I had to double deserialize it as the json is not really in correct form from the start, jenkins does not pretty writes it also, it's nasty.
Hope it'll help