### PR TITLE
Add delete job method, follow redirects manually

### DIFF
--- a/src/Narochno.Jenkins/JenkinsClient.cs
+++ b/src/Narochno.Jenkins/JenkinsClient.cs
@@ -23,7 +23,7 @@ namespace Narochno.Jenkins
 {
     public class JenkinsClient : IJenkinsClient
     {
-        private readonly HttpClient httpClient = new HttpClient();
+        private readonly HttpClient httpClient;
         private readonly JenkinsConfig jenkinsConfig;
         private readonly JsonSerializerSettings serializerSettings = new JsonSerializerSettings
         {
@@ -36,6 +36,13 @@ namespace Narochno.Jenkins
             {
                 throw new ArgumentNullException(nameof(jenkinsConfig));
             }
+
+            var handler = new HttpClientHandler()
+            {
+                AllowAutoRedirect = false
+            };
+
+            httpClient = new HttpClient(handler);
 
             this.jenkinsConfig = jenkinsConfig;
 
@@ -120,9 +127,23 @@ namespace Narochno.Jenkins
             var requestUri = jenkinsConfig.JenkinsUrl + "/createItem" + $"?name={newJobName}&mode=copy&from={fromJobName}";
             var content = new StringContent("", Encoding.UTF8, "application/xml");
 
-            var response = await GetRetryPolicy().ExecuteAsync(() => httpClient.PostAsync(requestUri, content, ctx));
+            HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Post, requestUri)
+            {
+                Content = content
+            };
 
+            var response = await GetRetryPolicy().ExecuteAsync(() => httpClient.SendAsync(message, ctx));
+
+            response = await FollowRedirect(response);
+            
             response.EnsureSuccessStatusCode();
+        }
+
+        private async Task<HttpResponseMessage> FollowRedirect(HttpResponseMessage response)
+        {
+            if (response.StatusCode != HttpStatusCode.Redirect) return response;
+
+            return await GetRetryPolicy().ExecuteAsync(() => httpClient.GetAsync(response.Headers.Location.AbsoluteUri));
         }
 
         public async Task<string> DownloadJobConfig(string job, CancellationToken ctx = default(CancellationToken))
@@ -151,6 +172,8 @@ namespace Narochno.Jenkins
 
             var response = await GetRetryPolicy().ExecuteAsync(() => httpClient.PostAsync(jenkinsConfig.JenkinsUrl + "/job/" + job + "/enable", content, ctx));
 
+            response = await FollowRedirect(response);
+
             response.EnsureSuccessStatusCode();
         }
 
@@ -159,6 +182,8 @@ namespace Narochno.Jenkins
             var content = new StringContent("");
 
             var response = await GetRetryPolicy().ExecuteAsync(() => httpClient.PostAsync(jenkinsConfig.JenkinsUrl + "/job/" + job + "/disable", content, ctx));
+
+            response = await FollowRedirect(response);
 
             response.EnsureSuccessStatusCode();
         }

--- a/src/Narochno.Jenkins/JenkinsClient.cs
+++ b/src/Narochno.Jenkins/JenkinsClient.cs
@@ -188,6 +188,17 @@ namespace Narochno.Jenkins
             response.EnsureSuccessStatusCode();
         }
 
+        public async Task DeleteJob(string job, CancellationToken ctx = default(CancellationToken))
+        {
+            var content = new StringContent("");
+
+            var response = await GetRetryPolicy().ExecuteAsync(() => httpClient.PostAsync(jenkinsConfig.JenkinsUrl + "/job/" + job + "/doDelete", content, ctx));
+
+            response = await FollowRedirect(response);
+
+            response.EnsureSuccessStatusCode();
+        }
+
         public RetryPolicy<HttpResponseMessage> GetRetryPolicy()
         {
             return Policy

--- a/src/Narochno.Jenkins/Narochno.Jenkins.csproj
+++ b/src/Narochno.Jenkins/Narochno.Jenkins.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A simple Jenkins client, providing a C# wrapper around the default Jenkins API.</Description>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <Authors>alanedwardes</Authors>
     <TargetFramework>netstandard1.3</TargetFramework>
     <AssemblyName>Narochno.Jenkins</AssemblyName>


### PR DESCRIPTION
For some reason newer version of HttpClient does not send auth info when follows redirects. So disable it, and follow redirects manually sending all required headers.