### PR TITLE
Add sub-jobs to JobInfo object

### DIFF
--- a/src/Narochno.Jenkins/Entities/Jobs/JobInfo.cs
+++ b/src/Narochno.Jenkins/Entities/Jobs/JobInfo.cs
@@ -17,6 +17,7 @@ namespace Narochno.Jenkins.Entities.Jobs
         public long NextBuildNumber { get; set; }
         public IList<HealthReport> HealthReport { get; set; } = new List<HealthReport>();
         public IList<Build> Builds { get; set; } = new List<Build>();
+        public IList<Job> Jobs { get; set; } = new List<Job>();
         public Build FirstBuild { get; set; }
         public Build LastBuild { get; set; }
         public Build LastCompletedBuild { get; set; }


### PR DESCRIPTION
The field `Jobs` was missing on `JobInfo` object. When I call the API for Jenkins I wanted to work with builds in sub-jobs. 