### PR TITLE
Folder compatibility, new endpoints and CancellationToken.

### DIFF
--- a/src/Narochno.Jenkins/IJenkinsClient.cs
+++ b/src/Narochno.Jenkins/IJenkinsClient.cs
@@ -21,9 +21,21 @@ namespace Narochno.Jenkins
         Task BuildProject(string job, CancellationToken ctx = default(CancellationToken));
         Task BuildProjectWithParameters(string job, IDictionary<string, string> parameters, CancellationToken ctx = default(CancellationToken));
         Task CopyJob(string fromJobName, string newJobName, CancellationToken ctx = default(CancellationToken));
+        Task CopyJob(string fromJobName, string newJobName, string path, CancellationToken ctx = default(CancellationToken));
         Task<string> DownloadJobConfig(string job, CancellationToken ctx = default(CancellationToken));
         Task UploadJobConfig(string job, string xml, CancellationToken ctx = default(CancellationToken));
         Task EnableJob(string job, CancellationToken ctx = default(CancellationToken));
         Task DisableJob(string job, CancellationToken ctx = default(CancellationToken));
+        Task DeleteJob(string job, CancellationToken ctx = default(CancellationToken));
+        Task<bool> ExistsJob(string job, CancellationToken ctx = default(CancellationToken));
+        Task CreateJob(string job, string xml, CancellationToken ctx = default(CancellationToken));
+        Task CreateJob(string job, string xml, string path, CancellationToken ctx = default(CancellationToken));
+        Task CreateFolder(string folder, CancellationToken ctx = default(CancellationToken));
+        Task CreateFolder(string folder, string path, CancellationToken ctx = default(CancellationToken));
+        Task DeleteFolder(string folder, CancellationToken ctx = default(CancellationToken));
+        Task QuietDown(string reason = "", CancellationToken ctx = default(CancellationToken));
+        Task CancelQuietDown(CancellationToken ctx = default(CancellationToken));
+        Task Restart(CancellationToken ctx = default(CancellationToken));
+        Task SafeRestart(CancellationToken ctx = default(CancellationToken));
     }
 }

--- a/src/Narochno.Jenkins/JenkinsClient.cs
+++ b/src/Narochno.Jenkins/JenkinsClient.cs
@@ -244,7 +244,7 @@ namespace Narochno.Jenkins
         
         public async Task DeleteFolder(string folder, CancellationToken ctx = default(CancellationToken))
         {
-            //Yes, delete job/folder is the same. As this might not be transparent we have this endpoint.
+            //Yes, delete job/folder are the same. As this might not be transparent we have this endpoint.
             await DeleteJob(folder, ctx);
         }
 


### PR DESCRIPTION
- Added several endpoints regarding jobs, folders and restarting Jenkins.
- Made the existing endpoints easier to work with the complicated Jenkins folder URL logic (see function JobPath).
- Regarding the CancellationToken I added the defaults to make it consistent with the interface. Furthermore in some places the token was not applied.
- DeleteJob was missing in the interface.

Please tell me if something else is needed to accept this merge request.

BTW, thanks for this great library :-)